### PR TITLE
use unique canonical page ids

### DIFF
--- a/lib/get-canonical-page-id.ts
+++ b/lib/get-canonical-page-id.ts
@@ -25,10 +25,10 @@ export function getCanonicalPageId(
     })
 
     // Optionally append a short hash to ensure uniqueness
-    if (canonicalId) {
-      const shortHash = pageId.slice(0, 4)
-      return `${canonicalId}-${shortHash}`
-    }
+    // if (canonicalId) {
+    //   const shortHash = pageId.slice(0, 4)
+    //   return `${canonicalId}-${shortHash}`
+    // }
 
     return canonicalId
   }

--- a/lib/get-canonical-page-id.ts
+++ b/lib/get-canonical-page-id.ts
@@ -20,8 +20,16 @@ export function getCanonicalPageId(
   if (override) {
     return override
   } else {
-    return getCanonicalPageIdImpl(pageId, recordMap, {
+    const canonicalId = getCanonicalPageIdImpl(pageId, recordMap, {
       uuid
     })
+
+    // Optionally append a short hash to ensure uniqueness
+    if (canonicalId) {
+      const shortHash = pageId.slice(0, 4)
+      return `${canonicalId}-${shortHash}`
+    }
+
+    return canonicalId
   }
 }

--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -68,25 +68,29 @@ async function getAllPagesImpl(
         return map
       }
 
-      const canonicalPageId = getCanonicalPageId(pageId, recordMap, {
+      let canonicalPageId = getCanonicalPageId(pageId, recordMap, {
         uuid
       })
 
+      // Keep first occurrence clean, add counter only to duplicates
+      const originalId = canonicalPageId
       if (map[canonicalPageId]) {
-        // you can have multiple pages in different collections that have the same id
-        // TODO: we may want to error if neither entry is a collection page
-        console.warn('error duplicate canonical page id', {
-          canonicalPageId,
-          pageId,
-          existingPageId: map[canonicalPageId]
+        let counter = 2
+        console.warn('Duplicate canonical ID detected:', {
+          originalId,
+          existingPageId: map[canonicalPageId],
+          newPageId: pageId
         })
+        do {
+          canonicalPageId = `${originalId}-${counter}`
+          counter++
+        } while (map[canonicalPageId])
+        console.log('Generated new canonical ID:', canonicalPageId)
+      }
 
-        return map
-      } else {
-        return {
-          ...map,
-          [canonicalPageId]: pageId
-        }
+      return {
+        ...map,
+        [canonicalPageId]: pageId
       }
     },
     {}

--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -16,9 +16,24 @@ export async function getSiteMap(): Promise<types.SiteMap> {
     config.rootNotionSpaceId
   )
 
+  // Add duplicate detection
+  const canonicalPageMap: { [canonicalPageId: string]: string } = {}
+  const seenCanonicalIds = new Set()
+
+  // Filter out duplicates while keeping the first occurrence
+  Object.entries(partialSiteMap.canonicalPageMap).forEach(([canonicalId, pageId]) => {
+    if (!seenCanonicalIds.has(canonicalId)) {
+      canonicalPageMap[canonicalId] = pageId
+      seenCanonicalIds.add(canonicalId)
+    } else {
+      console.warn(`Duplicate canonical ID detected: ${canonicalId}. Keeping first occurrence.`)
+    }
+  })
+
   return {
     site: config.site,
-    ...partialSiteMap
+    ...partialSiteMap,
+    canonicalPageMap // Use the de-duped map
   } as types.SiteMap
 }
 


### PR DESCRIPTION
#### Description

Added error handling in getSiteMap() to detect and handle duplicate canonical IDs.
Added an ID hash to the link to avoid duplicates.

#### Notion Test Page ID

1627bef4856e400ba7572c37ba7921f4
