### PR TITLE
Unify privacy policy and terms of service layout with main site

### DIFF
--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+import { Footer } from './Footer'
+
+export const PageLayout: React.FC<{
+  children: React.ReactNode
+}> = ({ children }) => {
+  return (
+    <div className='notion notion-app'>
+      <div className='notion-frame'>
+        <header className='notion-header'>
+          <div className='notion-nav-header'>
+            <div className='breadcrumbs'>
+              <a href='/' className='breadcrumb active'>
+                <span className='title'>Coursetexts</span>
+              </a>
+            </div>
+          </div>
+        </header>
+        <div className='notion-page-scroller'>
+          <main
+            style={{ marginBottom: '2rem' }}
+            className='notion-page notion-page-no-cover notion-page-has-icon notion-page-has-text-icon notion-full-page'
+          >
+            {children}
+          </main>
+        </div>
+        <Footer />
+      </div>
+    </div>
+  )
+}

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,6 +1,8 @@
 import Head from 'next/head'
 import React from 'react'
 
+import { PageLayout } from '@/components/PageLayout'
+
 const PrivacyAndPolicy = () => {
   return (
     <>
@@ -8,191 +10,159 @@ const PrivacyAndPolicy = () => {
         <title>Coursetexts Privacy Policy</title>
         <meta name='description' content='Coursetexts Privacy Policy' />
       </Head>
-      <div className='notion notion-app'>
-        <div className='notion-frame'>
-          <header className='notion-header'>
-            <div className='notion-nav-header'>
-              <div className='breadcrumbs'>
-                <div className='breadcrumb active'>
-                  <span className='title'>Coursetexts</span>
-                </div>
-                <nav className='nav-container'>
-                  <a href='/' className='nav-link'>
-                    Coursetexts
-                  </a>
-                  {/* <a
-                    href='/about-9a2ace4be0dc4d928e7d304a44a6afe8'
-                    className='nav-link'
-                  >
-                    About
-                  </a> */}
-                  <a href='/why' className='nav-link'>
-                    Why Coursetexts?
-                  </a>
-                </nav>
-              </div>
-            </div>
-          </header>
-          <div className='notion-page-scroller'>
-            <main
-              style={{ marginBottom: '2rem' }}
-              className='notion-page notion-page-no-cover notion-page-has-icon notion-page-has-text-icon notion-full-page'
-            >
-              <h1 className='notion-title'>Coursetexts Privacy Policy</h1>
-              <div style={{ marginBottom: '1rem' }} className='notion-text'>
-                Last updated: 10-21-2024
-              </div>
-              <h2 style={{ marginBottom: '1rem' }} className='notion-h-title'>
-                1. Introduction
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Coursetexts (
-                <span>&quot;we&quot;, &quot;our&quot;, or &quot;us&quot;</span>)
-                is committed to protecting your privacy. This Privacy Policy
-                explains how we collect, use, disclose, and safeguard your
-                information when you visit our website coursetexts.com (
-                <span>&quot;the Site&quot;</span>) or use our services.
-                Coursetexts has neither sought nor received permission from any
-                university to open-source courses that were taught at that
-                university. It is not affiliated with, sponsored by, or endorsed
-                by any university.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                2. Information We Collect
-              </h2>
-              <h3>2.1 Information You Provide</h3>
-              <p className='notion-text'>
-                We do not require users to create accounts or provide any
-                personal information to access course notes on our Site.
-              </p>
-              <p className='notion-text'>
-                For professors who wish to update their course pages, upon
-                sign-in we collect:
-              </p>
-              <ul
-                style={{ marginBottom: '2rem' }}
-                className='notion-list notion-list-disc'
-              >
-                <li>Name</li>
-                <li>Email address</li>
-                <li>
-                  Basic profile information associated with Google
-                  authentication
-                </li>
-              </ul>
-
-              <h3>2.2 Automatically Collected Information</h3>
-              <p className='notion-text'>
-                When you visit the Site, we may automatically collect certain
-                information about your device, including:
-              </p>
-              <ul
-                style={{ marginBottom: '2rem' }}
-                className='notion-list notion-list-disc'
-              >
-                <li>IP address</li>
-                <li>Browser type</li>
-                <li>Operating system</li>
-                <li>Access times</li>
-                <li>Pages viewed</li>
-              </ul>
-              <h2 style={{ marginBottom: '1rem' }}>
-                3. How We Use Your Information
-              </h2>
-              <p className='notion-text'>
-                We use the information we collect to:
-              </p>
-              <ul
-                style={{ marginBottom: '2rem' }}
-                className='notion-list notion-list-disc'
-              >
-                <li>Provide and maintain our services</li>
-                <li>Allow professors to update their course pages</li>
-                <li>Improve and optimize our services</li>
-                <li>Improve usage patterns</li>
-              </ul>
-              <h2 style={{ marginBottom: '1rem' }}>
-                4. Sharing of Your Information
-              </h2>
-              <p className='notion-text'>
-                We do not sell, rent, or trade your personal information to
-                third parties. We may share your information in the following
-                situations:
-              </p>
-              <ul
-                style={{ marginBottom: '2rem' }}
-                className='notion-list notion-list-disc'
-              >
-                <li>With your consent</li>
-                <li>To comply with legal obligations</li>
-                <li>To protect and defend our rights and property</li>
-              </ul>
-              <h2 style={{ marginBottom: '1rem' }}>5. Data Security</h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                We implement reasonable security measures to protect your
-                information. However, no method of transmission over the
-                internet or electronic storage is 100% secure, and we cannot
-                guarantee absolute security.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                6. Data Retention and Deletion
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                We only retain user Google email addresses, and only for as long
-                as necessary to provide our services. Users may request deletion
-                of their Google-associated account data at any time by
-                contacting us at coursetexts@mit.edu, or revoking access via
-                Google settings. Upon verification, we will permanently delete
-                all associated personal data from our systems within 30 days.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>7. Third-Party Links</h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Our Site may contain links to third-party websites. We are not
-                responsible for the privacy practices or content of these sites.
-                We encourage you to review the privacy policies of any
-                third-party sites you visit.
-              </p>
-              <h2
-                style={{ marginBottom: '1rem' }}
-              >{`8. Children's Privacy`}</h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Our Site is not intended for children under 13 years of age. We
-                do not knowingly collect personal information from children
-                under 13.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                9. Changes to This Privacy Policy
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                We may update our Privacy Policy from time to time. We will
-                notify you of any changes by posting the new Privacy Policy on
-                this page and updating the &quot;Last updated&quot; date.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                10. Consent and Authorization
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                We operate with explicit consent and authorization from Canvas
-                for our platform operations and from the faculty members whose
-                course materials we host. Coursetexts has neither sought nor
-                received permission from any university to open-source courses
-                that were taught at that university. Faculty members and
-                universities do not have access to any personal information from
-                this site.
-              </p>
-
-              <h2 style={{ marginBottom: '1rem' }}>11. Contact Us</h2>
-              <p className='notion-text'>
-                If you have any questions about this Privacy Policy, please
-                contact us at:
-              </p>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Email: coursetexts@mit.edu
-              </p>
-            </main>
-          </div>
+      <PageLayout>
+        <h1 className='notion-title'>Coursetexts Privacy Policy</h1>
+        <div style={{ marginBottom: '1rem' }} className='notion-text'>
+          Last updated: 10-21-2024
         </div>
-      </div>
+        <h2 style={{ marginBottom: '1rem' }} className='notion-h-title'>
+          1. Introduction
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Coursetexts (
+          <span>&quot;we&quot;, &quot;our&quot;, or &quot;us&quot;</span>)
+          is committed to protecting your privacy. This Privacy Policy
+          explains how we collect, use, disclose, and safeguard your
+          information when you visit our website coursetexts.com (
+          <span>&quot;the Site&quot;</span>) or use our services.
+          Coursetexts has neither sought nor received permission from any
+          university to open-source courses that were taught at that
+          university. It is not affiliated with, sponsored by, or endorsed
+          by any university.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          2. Information We Collect
+        </h2>
+        <h3>2.1 Information You Provide</h3>
+        <p className='notion-text'>
+          We do not require users to create accounts or provide any
+          personal information to access course notes on our Site.
+        </p>
+        <p className='notion-text'>
+          For professors who wish to update their course pages, upon
+          sign-in we collect:
+        </p>
+        <ul
+          style={{ marginBottom: '2rem' }}
+          className='notion-list notion-list-disc'
+        >
+          <li>Name</li>
+          <li>Email address</li>
+          <li>
+            Basic profile information associated with Google
+            authentication
+          </li>
+        </ul>
+
+        <h3>2.2 Automatically Collected Information</h3>
+        <p className='notion-text'>
+          When you visit the Site, we may automatically collect certain
+          information about your device, including:
+        </p>
+        <ul
+          style={{ marginBottom: '2rem' }}
+          className='notion-list notion-list-disc'
+        >
+          <li>IP address</li>
+          <li>Browser type</li>
+          <li>Operating system</li>
+          <li>Access times</li>
+          <li>Pages viewed</li>
+        </ul>
+        <h2 style={{ marginBottom: '1rem' }}>
+          3. How We Use Your Information
+        </h2>
+        <p className='notion-text'>
+          We use the information we collect to:
+        </p>
+        <ul
+          style={{ marginBottom: '2rem' }}
+          className='notion-list notion-list-disc'
+        >
+          <li>Provide and maintain our services</li>
+          <li>Allow professors to update their course pages</li>
+          <li>Improve and optimize our services</li>
+          <li>Improve usage patterns</li>
+        </ul>
+        <h2 style={{ marginBottom: '1rem' }}>
+          4. Sharing of Your Information
+        </h2>
+        <p className='notion-text'>
+          We do not sell, rent, or trade your personal information to
+          third parties. We may share your information in the following
+          situations:
+        </p>
+        <ul
+          style={{ marginBottom: '2rem' }}
+          className='notion-list notion-list-disc'
+        >
+          <li>With your consent</li>
+          <li>To comply with legal obligations</li>
+          <li>To protect and defend our rights and property</li>
+        </ul>
+        <h2 style={{ marginBottom: '1rem' }}>5. Data Security</h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          We implement reasonable security measures to protect your
+          information. However, no method of transmission over the
+          internet or electronic storage is 100% secure, and we cannot
+          guarantee absolute security.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          6. Data Retention and Deletion
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          We only retain user Google email addresses, and only for as long
+          as necessary to provide our services. Users may request deletion
+          of their Google-associated account data at any time by
+          contacting us at coursetexts@mit.edu, or revoking access via
+          Google settings. Upon verification, we will permanently delete
+          all associated personal data from our systems within 30 days.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>7. Third-Party Links</h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Our Site may contain links to third-party websites. We are not
+          responsible for the privacy practices or content of these sites.
+          We encourage you to review the privacy policies of any
+          third-party sites you visit.
+        </p>
+        <h2
+          style={{ marginBottom: '1rem' }}
+        >{`8. Children's Privacy`}</h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Our Site is not intended for children under 13 years of age. We
+          do not knowingly collect personal information from children
+          under 13.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          9. Changes to This Privacy Policy
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          We may update our Privacy Policy from time to time. We will
+          notify you of any changes by posting the new Privacy Policy on
+          this page and updating the &quot;Last updated&quot; date.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          10. Consent and Authorization
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          We operate with explicit consent and authorization from Canvas
+          for our platform operations and from the faculty members whose
+          course materials we host. Coursetexts has neither sought nor
+          received permission from any university to open-source courses
+          that were taught at that university. Faculty members and
+          universities do not have access to any personal information from
+          this site.
+        </p>
+
+        <h2 style={{ marginBottom: '1rem' }}>11. Contact Us</h2>
+        <p className='notion-text'>
+          If you have any questions about this Privacy Policy, please
+          contact us at:
+        </p>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Email: coursetexts@mit.edu
+        </p>
+      </PageLayout>
     </>
   )
 }

--- a/pages/terms-of-service.tsx
+++ b/pages/terms-of-service.tsx
@@ -1,155 +1,125 @@
 import Head from 'next/head'
 import React from 'react'
 
+import { PageLayout } from '@/components/PageLayout'
+
 const TermsOfService = () => {
   return (
     <>
       <Head>
         <title>Coursetexts Terms of Service</title>
-        <meta name='description' content='Coursetexts Privacy Policy' />
+        <meta name='description' content='Coursetexts Terms of Service' />
       </Head>
-      <div className='notion notion-app'>
-        <div className='notion-frame'>
-          <header className='notion-header'>
-            <div className='notion-nav-header'>
-              <div className='breadcrumbs'>
-                <div className='breadcrumb active'>
-                  <span className='title'>Coursetexts</span>
-                </div>
-                <nav className='nav-container'>
-                  <a href='/' className='nav-link'>
-                    Coursetexts
-                  </a>
-                  <a
-                    href='/about-9a2ace4be0dc4d928e7d304a44a6afe8'
-                    className='nav-link'
-                  >
-                    About
-                  </a>
-                </nav>
-              </div>
-            </div>
-          </header>
-          <div className='notion-page-scroller'>
-            <main
-              style={{ marginBottom: '2rem' }}
-              className='notion-page notion-page-no-cover notion-page-has-icon notion-page-has-text-icon notion-full-page'
-            >
-              <h1 className='notion-title'>Coursetexts Terms of Service</h1>
-              <div style={{ marginBottom: '1rem' }} className='notion-text'>
-                Last updated: 10-21-2024
-              </div>
-              <h2 style={{ marginBottom: '1rem' }} className='notion-h-title'>
-                1. Acceptance of Terms
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                By accessing and using coursetexts.com (the{' '}
-                <span>&quot;Site&quot;</span>), you accept and agree to be bound
-                by these Terms of Service. If you do not agree to these terms,
-                please do not use the Site.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                2. Description of Service
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Coursetexts provides access to course materials and notes with
-                authorization from Canvas only. The service allows professors to
-                update their course pages and students to access course
-                materials. Coursetexts has neither sought nor received
-                permission from any university to open-source courses that were
-                taught at that university. It is not affiliated with, sponsored
-                by, or endorsed by any university. All course materials are
-                licensed under the Creative Commons
-                Attribution-NonCommercial-ShareAlike (CC BY-NC-SA) license.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>3. User Responsibilities</h2>
-              <p className='notion-text'>Users of the Site agree to:</p>
-              <ul
-                style={{ marginBottom: '2rem' }}
-                className='notion-list notion-list-disc'
-              >
-                <li>Use the service for lawful purposes only</li>
-                <li>
-                  Not attempt to gain unauthorized access to any portion of the
-                  Site
-                </li>
-                <li>Not interfere with the proper functioning of the Site</li>
-                <li>Not distribute or share access credentials</li>
-                <li>Respect intellectual property rights</li>
-                <li>
-                  Comply with the CC BY-NC-SA license terms when using course
-                  materials
-                </li>
-              </ul>
-              <h2
-                style={{ marginBottom: '1rem' }}
-                className='text-2xl font-semibold mb-4'
-              >
-                4. Intellectual Property
-              </h2>
-              <p style={{ marginBottom: '2rem' }}>
-                All course content on the Site is licensed under the Creative
-                Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)
-                license. This means you are free to share and adapt the
-                materials for non-commercial purposes, as long as you give
-                appropriate credit, indicate if changes were made, and
-                distribute your contributions under the same license. All other
-                content on the Site, including but not limited to text,
-                graphics, logos, and software, is the property of Coursetexts or
-                its content providers and is protected by copyright and other
-                intellectual property laws.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>5. Professor Access</h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Professors may update their course pages through Google
-                authentication. By doing so, they grant Coursetexts permission
-                to display and distribute their provided materials to authorized
-                users under the CC BY-NC-SA license.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                6. Disclaimer of Warranties
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                The Site is provided <span>&quot;as is&quot;</span> without any
-                warranties, express or implied. We do not guarantee the
-                accuracy, completeness, or reliability of any content on the
-                Site.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                7. Limitation of Liability
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Coursetexts shall not be liable for any indirect, incidental,
-                special, consequential, or punitive damages arising from your
-                use of the Site or any content therein.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>
-                8. Modifications to Service
-              </h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                We reserve the right to modify or discontinue the Service at any
-                time without notice. We shall not be liable to you or any third
-                party for any modification, suspension, or discontinuance of the
-                Service.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>9. Governing Law</h2>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                These Terms shall be governed by and construed in accordance
-                with the laws of Massachusetts, without regard to its conflict
-                of law provisions.
-              </p>
-              <h2 style={{ marginBottom: '1rem' }}>10. Contact Information</h2>
-              <p className='notion-text'>
-                For any questions regarding these Terms of Service, please
-                contact us at:
-              </p>
-              <p style={{ marginBottom: '2rem' }} className='notion-text'>
-                Email: coursetexts@mit.edu
-              </p>
-            </main>
-          </div>
+      <PageLayout>
+        <h1 className='notion-title'>Coursetexts Terms of Service</h1>
+        <div style={{ marginBottom: '1rem' }} className='notion-text'>
+          Last updated: 10-21-2024
         </div>
-      </div>
+        <h2 style={{ marginBottom: '1rem' }} className='notion-h-title'>
+          1. Acceptance of Terms
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          By accessing and using coursetexts.com (the{' '}
+          <span>&quot;Site&quot;</span>), you accept and agree to be bound
+          by these Terms of Service. If you do not agree to these terms,
+          please do not use the Site.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          2. Description of Service
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Coursetexts provides access to course materials and notes with
+          authorization from Canvas only. The service allows professors to
+          update their course pages and students to access course
+          materials. Coursetexts has neither sought nor received
+          permission from any university to open-source courses that were
+          taught at that university. It is not affiliated with, sponsored
+          by, or endorsed by any university. All course materials are
+          licensed under the Creative Commons
+          Attribution-NonCommercial-ShareAlike (CC BY-NC-SA) license.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>3. User Responsibilities</h2>
+        <p className='notion-text'>Users of the Site agree to:</p>
+        <ul
+          style={{ marginBottom: '2rem' }}
+          className='notion-list notion-list-disc'
+        >
+          <li>Use the service for lawful purposes only</li>
+          <li>
+            Not attempt to gain unauthorized access to any portion of the
+            Site
+          </li>
+          <li>Not interfere with the proper functioning of the Site</li>
+          <li>Not distribute or share access credentials</li>
+          <li>Respect intellectual property rights</li>
+          <li>
+            Comply with the CC BY-NC-SA license terms when using course
+            materials
+          </li>
+        </ul>
+        <h2 style={{ marginBottom: '1rem' }}>
+          4. Intellectual Property
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          All course content on the Site is licensed under the Creative
+          Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)
+          license. This means you are free to share and adapt the
+          materials for non-commercial purposes, as long as you give
+          appropriate credit, indicate if changes were made, and
+          distribute your contributions under the same license. All other
+          content on the Site, including but not limited to text,
+          graphics, logos, and software, is the property of Coursetexts or
+          its content providers and is protected by copyright and other
+          intellectual property laws.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>5. Professor Access</h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Professors may update their course pages through Google
+          authentication. By doing so, they grant Coursetexts permission
+          to display and distribute their provided materials to authorized
+          users under the CC BY-NC-SA license.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          6. Disclaimer of Warranties
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          The Site is provided <span>&quot;as is&quot;</span> without any
+          warranties, express or implied. We do not guarantee the
+          accuracy, completeness, or reliability of any content on the
+          Site.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          7. Limitation of Liability
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Coursetexts shall not be liable for any indirect, incidental,
+          special, consequential, or punitive damages arising from your
+          use of the Site or any content therein.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>
+          8. Modifications to Service
+        </h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          We reserve the right to modify or discontinue the Service at any
+          time without notice. We shall not be liable to you or any third
+          party for any modification, suspension, or discontinuance of the
+          Service.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>9. Governing Law</h2>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          These Terms shall be governed by and construed in accordance
+          with the laws of Massachusetts, without regard to its conflict
+          of law provisions.
+        </p>
+        <h2 style={{ marginBottom: '1rem' }}>10. Contact Information</h2>
+        <p className='notion-text'>
+          For any questions regarding these Terms of Service, please
+          contact us at:
+        </p>
+        <p style={{ marginBottom: '2rem' }} className='notion-text'>
+          Email: coursetexts@mit.edu
+        </p>
+      </PageLayout>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Both legal pages (privacy policy & terms of service) had hardcoded, inconsistent headers (different nav links from each other and from the main site) and were missing the site footer entirely
- Created a shared `PageLayout` component that wraps standalone pages with the same header and footer used across the rest of the site
- Updated both pages to use `PageLayout`, giving them consistent navigation and the full site footer

## Test plan
- [ ] Verify `/privacy-policy` renders with the site header and footer
- [ ] Verify `/terms-of-service` renders with the site header and footer
- [ ] Verify the "Coursetexts" breadcrumb in the header links back to `/`
- [ ] Verify the footer matches what appears on other pages (donation link, course request form, social icons, legal links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)