### PR TITLE
Fix SSR crash from malformed Notion data & preview site auth bugs

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 
 import cs from 'classnames'
 // import { PageBlock } from 'notion-types'
+import { Block } from 'notion-types'
 import { formatDate, getBlockTitle, getPageProperty } from 'notion-utils'
 import BodyClassName from 'react-body-classname'
 import { Root, createRoot } from 'react-dom/client'
@@ -279,7 +280,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
     process.env.NEXT_PUBLIC_NOTION_PAGE_ID === NOTION_PRODUCTION_URL
 
   const keys = Object.keys(recordMap?.block || {})
-  const block = recordMap?.block?.[keys[0]]?.value
+  const block = recordMap?.block?.[keys[0]]?.value as Block | undefined
 
   let title = 'Untitled'
   if (block && (block as any).properties) {

--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'

--- a/lib/acl.ts
+++ b/lib/acl.ts
@@ -35,8 +35,8 @@ export async function pageAcl({
     }
   }
 
-  const rootValue = recordMap.block[rootKey]?.value
-  const rootSpaceId = rootValue?.space_id
+  const rootBlock = recordMap.block[rootKey] as any
+  const rootSpaceId = rootBlock?.value?.space_id
 
   if (
     rootSpaceId &&

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,7 +29,7 @@ if (!rootNotionPageId) {
 export const rootNotionSpaceId: string | null = parsePageId(
   getSiteConfig('rootNotionSpaceId', null),
   { uuid: true }
-)
+) || null
 
 export const pageUrlOverrides = cleanPageUrlMap(
   getSiteConfig('pageUrlOverrides', {}) || {},

--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -48,8 +48,8 @@ async function getAllPagesImpl(
         return map
       }
 
-      const block = recordMap.block[pageId]?.value
-      if (!(getPageProperty<boolean|null>('Public', block, recordMap) ?? true)) {
+      const block = (recordMap.block[pageId] as any)?.value
+      if (!(getPageProperty<boolean | null>('Public', block as any, recordMap) ?? true)) {
         return map
       }
 

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -1,7 +1,20 @@
 import { Block } from 'notion-types'
-import { defaultMapImageUrl } from 'react-notion-x'
 
 import { defaultPageCover, defaultPageIcon } from './config'
+
+const defaultMapImageUrl = (url: string, block: Block) => {
+  if (!url) return url
+
+  if (url.startsWith('data:')) {
+    return url
+  }
+
+  if (url.startsWith('/images')) {
+    return url
+  }
+
+  return `https://www.notion.so${url.startsWith('/') ? url : `/${url}`}`
+}
 
 export const mapImageUrl = (url: string, block: Block) => {
   if (url === defaultPageCover || url === defaultPageIcon) {

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -1,21 +1,7 @@
 import { Block } from 'notion-types'
+import { defaultMapImageUrl } from 'notion-utils'
 
 import { defaultPageCover, defaultPageIcon } from './config'
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const defaultMapImageUrl = (url: string, _block?: Block) => {
-  if (!url) return url
-
-  if (url.startsWith('data:')) {
-    return url
-  }
-
-  if (url.startsWith('/images')) {
-    return url
-  }
-
-  return `https://www.notion.so${url.startsWith('/') ? url : `/${url}`}`
-}
 
 export const mapImageUrl = (url: string, block: Block) => {
   if (url === defaultPageCover || url === defaultPageIcon) {

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -2,7 +2,8 @@ import { Block } from 'notion-types'
 
 import { defaultPageCover, defaultPageIcon } from './config'
 
-const defaultMapImageUrl = (url: string, _block: Block) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const defaultMapImageUrl = (url: string, _block?: Block) => {
   if (!url) return url
 
   if (url.startsWith('data:')) {

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -2,7 +2,7 @@ import { Block } from 'notion-types'
 
 import { defaultPageCover, defaultPageIcon } from './config'
 
-const defaultMapImageUrl = (url: string, block: Block) => {
+const defaultMapImageUrl = (url: string, _block: Block) => {
   if (!url) return url
 
   if (url.startsWith('data:')) {

--- a/lib/map-page-url.ts
+++ b/lib/map-page-url.ts
@@ -14,11 +14,22 @@ export const mapPageUrl =
   (pageId = '') => {
     const pageUuid = parsePageId(pageId, { uuid: true })
 
+    // Guard malformed page references from Notion blocks.
+    if (!pageUuid) {
+      return createUrl('/', searchParams)
+    }
+
     if (uuidToId(pageUuid) === site.rootNotionPageId) {
       return createUrl('/', searchParams)
     } else {
+      const canonical = getCanonicalPageId(pageUuid, recordMap, { uuid })
+
+      if (!canonical) {
+        return createUrl('/', searchParams)
+      }
+
       return createUrl(
-        `/${getCanonicalPageId(pageUuid, recordMap, { uuid })}`,
+        `/${canonical}`,
         searchParams
       )
     }
@@ -29,12 +40,20 @@ export const getCanonicalPageUrl =
   (pageId = '') => {
     const pageUuid = parsePageId(pageId, { uuid: true })
 
-    if (uuidToId(pageId) === site.rootNotionPageId) {
+    if (!pageUuid) {
+      return `https://${site.domain}`
+    }
+
+    if (uuidToId(pageUuid) === site.rootNotionPageId) {
       return `https://${site.domain}`
     } else {
-      return `https://${site.domain}/${getCanonicalPageId(pageUuid, recordMap, {
-        uuid
-      })}`
+      const canonical = getCanonicalPageId(pageUuid, recordMap, { uuid })
+
+      if (!canonical) {
+        return `https://${site.domain}`
+      }
+
+      return `https://${site.domain}/${canonical}`
     }
   }
 

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -8,7 +8,7 @@ import {
   navigationLinks,
   navigationStyle
 } from './config'
-import { notion } from './notion-api'
+import { getPageWithRetry, notion } from './notion-api'
 import { getPreviewImageMap } from './preview-images'
 
 const getNavigationLinkPages = pMemoize(
@@ -69,7 +69,17 @@ function sanitizeRecordMapBlocks(recordMap: ExtendedRecordMap, pageId: string) {
 }
 
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
-  let recordMap = await notion.getPage(pageId)
+  let recordMap: ExtendedRecordMap
+
+  try {
+    recordMap = await getPageWithRetry(pageId)
+  } catch (error: any) {
+    console.error('Failed to fetch Notion page after retries', {
+      pageId,
+      message: error?.message
+    })
+    return { block: {} } as ExtendedRecordMap
+  }
 
   // Validate that we received valid page data
   if (!recordMap || typeof recordMap !== 'object' || !recordMap.block) {
@@ -97,8 +107,15 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
   }
 
   if (isPreviewImageSupportEnabled) {
-    const previewImageMap = await getPreviewImageMap(recordMap)
-    ;(recordMap as any).preview_images = previewImageMap
+    try {
+      const previewImageMap = await getPreviewImageMap(recordMap)
+      ;(recordMap as any).preview_images = previewImageMap
+    } catch (error: any) {
+      console.warn('Failed to fetch preview images', {
+        pageId,
+        message: error?.message
+      })
+    }
   }
 
   return recordMap

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -37,9 +37,47 @@ const getNavigationLinkPages = pMemoize(
   }
 )
 
+function sanitizeRecordMapBlocks(recordMap: ExtendedRecordMap, pageId: string) {
+  const blockMap = (recordMap as any).block || {}
+  let removed = 0
+  let repaired = 0
+
+  for (const [blockId, blockEntry] of Object.entries<any>(blockMap)) {
+    const value = blockEntry?.value
+
+    // Remove malformed blocks which cannot be rendered safely.
+    if (!blockId || !value || typeof value !== 'object') {
+      delete blockMap[blockId]
+      removed += 1
+      continue
+    }
+
+    // Some Notion responses omit value.id; react-notion-x expects it.
+    if (!value.id) {
+      value.id = blockId
+      repaired += 1
+    }
+  }
+
+  if (removed || repaired) {
+    console.warn('Sanitized recordMap blocks', {
+      pageId,
+      removed,
+      repaired
+    })
+  }
+}
+
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
   let recordMap = await notion.getPage(pageId)
 
+  // Validate that we received valid page data
+  if (!recordMap || typeof recordMap !== 'object' || !recordMap.block) {
+    console.error(`Invalid recordMap received for pageId: ${pageId}`, { recordMap })
+    return { block: {} } as ExtendedRecordMap
+  }
+
+  sanitizeRecordMapBlocks(recordMap, pageId)
   if (navigationStyle !== 'default') {
     // ensure that any pages linked to in the custom navigation header have
     // their block info fully resolved in the page record map so we know
@@ -52,6 +90,9 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
           mergeRecordMaps(map, navigationLinkRecordMap),
         recordMap
       )
+
+      // Navigation page merges can also introduce malformed block entries.
+      sanitizeRecordMapBlocks(recordMap, pageId)
     }
   }
 

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -78,7 +78,7 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
       pageId,
       message: error?.message
     })
-    return { block: {} } as ExtendedRecordMap
+    throw error
   }
 
   // Validate that we received valid page data

--- a/lib/oembed.ts
+++ b/lib/oembed.ts
@@ -26,8 +26,10 @@ export const oembed = async ({
   const pageTitle = getPageTitle(page)
   if (pageTitle) title = pageTitle
 
-  const user = page.notion_user[Object.keys(page.notion_user)[0]]?.value
-  const name = [user.given_name, user.family_name]
+  const firstUserKey = Object.keys(page.notion_user || {})[0]
+  const firstUserEntry = (page.notion_user?.[firstUserKey] as any) || null
+  const user = firstUserEntry?.value
+  const name = [user?.given_name, user?.family_name]
     .filter(Boolean)
     .join(' ')
     .trim()

--- a/pages/api/notion-page-info.tsx
+++ b/pages/api/notion-page-info.tsx
@@ -28,13 +28,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const recordMap = await notion.getPage(pageId)
 
   const keys = Object.keys(recordMap?.block || {})
-  const block = recordMap?.block?.[keys[0]]?.value
+  const block = (recordMap?.block?.[keys[0]] as any)?.value
 
   if (!block) {
     throw new Error('Invalid recordMap for page')
   }
 
-  const blockSpaceId = block.space_id
+  const blockSpaceId = block?.space_id
 
   if (
     blockSpaceId &&

--- a/pages/feed.tsx
+++ b/pages/feed.tsx
@@ -41,7 +41,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     if (!recordMap) continue
 
     const keys = Object.keys(recordMap?.block || {})
-    const block = recordMap?.block?.[keys[0]]?.value
+    const block = (recordMap?.block?.[keys[0]] as any)?.value
     if (!block) continue
 
     const parentPage = getBlockParentPage(block, recordMap)


### PR DESCRIPTION
## Fix SSR crashes from malformed Notion data

### Root Cause
Malformed Notion blocks (e.g., missing IDs) caused `uuidToId()` to crash during SSR, leading to full-site outages.  
Preview issues were initially masked by auth middleware intercepting static assets.

### Fix
- Sanitize Notion `recordMap` before rendering (`sanitizeRecordMapBlocks`)
- Add guards to return `404` for invalid page data
- Fix config serialization (`null` vs `undefined`)
- Add retry logic for Notion API (429 handling)
- Resolve TypeScript + CI build issues

### Impact
- Eliminates SSR 500 crashes
- Pages render despite partial data corruption (graceful degradation)
- Invalid pages safely return `404`
- Preview styling/fonts fixed
- Stabilizes CI/build pipeline


## User Behavior After Fix

### Repaired blocks (missing IDs)
- Missing IDs are auto-injected
- Content renders normally via `react-notion-x`

### Corrupted blocks
- Unrecoverable blocks are removed
- Page renders बाकी content without interruption

### Invalid pages
- Clean `404 Page Not Found` instead of SSR crash

### Preview fixes
- Static assets no longer intercepted by middleware
- Fonts and CSS load correctly under auth

### Validation
- ✅ Builds pass
- ✅ Preview works with auth
- ✅ Previously failing pages no longer crash