### PR TITLE
Revert "Fix SSR crash from malformed Notion data & preview site auth bugs"

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
@@ -7,7 +6,6 @@ import { useRouter } from 'next/router'
 
 import cs from 'classnames'
 // import { PageBlock } from 'notion-types'
-import { Block } from 'notion-types'
 import { formatDate, getBlockTitle, getPageProperty } from 'notion-utils'
 import BodyClassName from 'react-body-classname'
 import { Root, createRoot } from 'react-dom/client'
@@ -281,7 +279,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
     process.env.NEXT_PUBLIC_NOTION_PAGE_ID === NOTION_PRODUCTION_URL
 
   const keys = Object.keys(recordMap?.block || {})
-  const block = recordMap?.block?.[keys[0]]?.value as Block | undefined
+  const block = recordMap?.block?.[keys[0]]?.value
 
   let title = 'Untitled'
   if (block && (block as any).properties) {

--- a/lib/acl.ts
+++ b/lib/acl.ts
@@ -35,8 +35,8 @@ export async function pageAcl({
     }
   }
 
-  const rootBlock = recordMap.block[rootKey] as any
-  const rootSpaceId = rootBlock?.value?.space_id
+  const rootValue = recordMap.block[rootKey]?.value
+  const rootSpaceId = rootValue?.space_id
 
   if (
     rootSpaceId &&

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,7 +29,7 @@ if (!rootNotionPageId) {
 export const rootNotionSpaceId: string | null = parsePageId(
   getSiteConfig('rootNotionSpaceId', null),
   { uuid: true }
-) || null
+)
 
 export const pageUrlOverrides = cleanPageUrlMap(
   getSiteConfig('pageUrlOverrides', {}) || {},

--- a/lib/get-site-map.ts
+++ b/lib/get-site-map.ts
@@ -48,8 +48,8 @@ async function getAllPagesImpl(
         return map
       }
 
-      const block = (recordMap.block[pageId] as any)?.value
-      if (!(getPageProperty<boolean | null>('Public', block as any, recordMap) ?? true)) {
+      const block = recordMap.block[pageId]?.value
+      if (!(getPageProperty<boolean|null>('Public', block, recordMap) ?? true)) {
         return map
       }
 

--- a/lib/map-image-url.ts
+++ b/lib/map-image-url.ts
@@ -1,5 +1,5 @@
 import { Block } from 'notion-types'
-import { defaultMapImageUrl } from 'notion-utils'
+import { defaultMapImageUrl } from 'react-notion-x'
 
 import { defaultPageCover, defaultPageIcon } from './config'
 

--- a/lib/map-page-url.ts
+++ b/lib/map-page-url.ts
@@ -14,22 +14,11 @@ export const mapPageUrl =
   (pageId = '') => {
     const pageUuid = parsePageId(pageId, { uuid: true })
 
-    // Guard malformed page references from Notion blocks.
-    if (!pageUuid) {
-      return createUrl('/', searchParams)
-    }
-
     if (uuidToId(pageUuid) === site.rootNotionPageId) {
       return createUrl('/', searchParams)
     } else {
-      const canonical = getCanonicalPageId(pageUuid, recordMap, { uuid })
-
-      if (!canonical) {
-        return createUrl('/', searchParams)
-      }
-
       return createUrl(
-        `/${canonical}`,
+        `/${getCanonicalPageId(pageUuid, recordMap, { uuid })}`,
         searchParams
       )
     }
@@ -40,20 +29,12 @@ export const getCanonicalPageUrl =
   (pageId = '') => {
     const pageUuid = parsePageId(pageId, { uuid: true })
 
-    if (!pageUuid) {
-      return `https://${site.domain}`
-    }
-
-    if (uuidToId(pageUuid) === site.rootNotionPageId) {
+    if (uuidToId(pageId) === site.rootNotionPageId) {
       return `https://${site.domain}`
     } else {
-      const canonical = getCanonicalPageId(pageUuid, recordMap, { uuid })
-
-      if (!canonical) {
-        return `https://${site.domain}`
-      }
-
-      return `https://${site.domain}/${canonical}`
+      return `https://${site.domain}/${getCanonicalPageId(pageUuid, recordMap, {
+        uuid
+      })}`
     }
   }
 

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -8,7 +8,7 @@ import {
   navigationLinks,
   navigationStyle
 } from './config'
-import { getPageWithRetry, notion } from './notion-api'
+import { notion } from './notion-api'
 import { getPreviewImageMap } from './preview-images'
 
 const getNavigationLinkPages = pMemoize(
@@ -37,57 +37,9 @@ const getNavigationLinkPages = pMemoize(
   }
 )
 
-function sanitizeRecordMapBlocks(recordMap: ExtendedRecordMap, pageId: string) {
-  const blockMap = (recordMap as any).block || {}
-  let removed = 0
-  let repaired = 0
-
-  for (const [blockId, blockEntry] of Object.entries<any>(blockMap)) {
-    const value = blockEntry?.value
-
-    // Remove malformed blocks which cannot be rendered safely.
-    if (!blockId || !value || typeof value !== 'object') {
-      delete blockMap[blockId]
-      removed += 1
-      continue
-    }
-
-    // Some Notion responses omit value.id; react-notion-x expects it.
-    if (!value.id) {
-      value.id = blockId
-      repaired += 1
-    }
-  }
-
-  if (removed || repaired) {
-    console.warn('Sanitized recordMap blocks', {
-      pageId,
-      removed,
-      repaired
-    })
-  }
-}
-
 export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
-  let recordMap: ExtendedRecordMap
+  let recordMap = await notion.getPage(pageId)
 
-  try {
-    recordMap = await getPageWithRetry(pageId)
-  } catch (error: any) {
-    console.error('Failed to fetch Notion page after retries', {
-      pageId,
-      message: error?.message
-    })
-    throw error
-  }
-
-  // Validate that we received valid page data
-  if (!recordMap || typeof recordMap !== 'object' || !recordMap.block) {
-    console.error(`Invalid recordMap received for pageId: ${pageId}`, { recordMap })
-    return { block: {} } as ExtendedRecordMap
-  }
-
-  sanitizeRecordMapBlocks(recordMap, pageId)
   if (navigationStyle !== 'default') {
     // ensure that any pages linked to in the custom navigation header have
     // their block info fully resolved in the page record map so we know
@@ -100,22 +52,12 @@ export async function getPage(pageId: string): Promise<ExtendedRecordMap> {
           mergeRecordMaps(map, navigationLinkRecordMap),
         recordMap
       )
-
-      // Navigation page merges can also introduce malformed block entries.
-      sanitizeRecordMapBlocks(recordMap, pageId)
     }
   }
 
   if (isPreviewImageSupportEnabled) {
-    try {
-      const previewImageMap = await getPreviewImageMap(recordMap)
-      ;(recordMap as any).preview_images = previewImageMap
-    } catch (error: any) {
-      console.warn('Failed to fetch preview images', {
-        pageId,
-        message: error?.message
-      })
-    }
+    const previewImageMap = await getPreviewImageMap(recordMap)
+    ;(recordMap as any).preview_images = previewImageMap
   }
 
   return recordMap

--- a/lib/oembed.ts
+++ b/lib/oembed.ts
@@ -26,10 +26,8 @@ export const oembed = async ({
   const pageTitle = getPageTitle(page)
   if (pageTitle) title = pageTitle
 
-  const firstUserKey = Object.keys(page.notion_user || {})[0]
-  const firstUserEntry = (page.notion_user?.[firstUserKey] as any) || null
-  const user = firstUserEntry?.value
-  const name = [user?.given_name, user?.family_name]
+  const user = page.notion_user[Object.keys(page.notion_user)[0]]?.value
+  const name = [user.given_name, user.family_name]
     .filter(Boolean)
     .join(' ')
     .trim()

--- a/pages/api/notion-page-info.tsx
+++ b/pages/api/notion-page-info.tsx
@@ -28,13 +28,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const recordMap = await notion.getPage(pageId)
 
   const keys = Object.keys(recordMap?.block || {})
-  const block = (recordMap?.block?.[keys[0]] as any)?.value
+  const block = recordMap?.block?.[keys[0]]?.value
 
   if (!block) {
     throw new Error('Invalid recordMap for page')
   }
 
-  const blockSpaceId = block?.space_id
+  const blockSpaceId = block.space_id
 
   if (
     blockSpaceId &&

--- a/pages/feed.tsx
+++ b/pages/feed.tsx
@@ -41,7 +41,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
     if (!recordMap) continue
 
     const keys = Object.keys(recordMap?.block || {})
-    const block = (recordMap?.block?.[keys[0]] as any)?.value
+    const block = recordMap?.block?.[keys[0]]?.value
     if (!block) continue
 
     const parentPage = getBlockParentPage(block, recordMap)


### PR DESCRIPTION
Reverts coursetexts/notion-site#106

<img width="1919" height="1128" alt="image" src="https://github.com/user-attachments/assets/5d05938f-3b54-4b4a-820b-6516ecb87938" />


preview shows this -- local rendering was perfectly fine
needs inspection