### PR TITLE
fix: support Railway deploys for course pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,29 +1,34 @@
 # ------------------------------------------------------------------------------
-# This is an example .env file.
-#
-# All of these environment vars must be defined either in your environment or in
-# a local .env file in order to run this app.
-#
-# @see https://github.com/rolodato/dotenv-safe for more details.
+# Example environment for local development and Railway deploys.
 # ------------------------------------------------------------------------------
 
-# Needs to be 'production' when deployed to prod
-VERCEL_ENV=
+# Required for local dev and production deploys
+NEXT_PUBLIC_NOTION_PAGE_ID=
+SESSION_SECRET=
 
-# Optional (for fathom analytics)
-#NEXT_PUBLIC_FATHOM_ID=
+# Optional production metadata / analytics
+NEXT_PUBLIC_NOTION_PAGE_ID_PREVIEW=
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+NEXT_PUBLIC_FATHOM_ID=
+NEXT_PUBLIC_POSTHOG_ID=
 
-# Optional (for PostHog analytics)
-#NEXT_PUBLIC_POSTHOG_ID=
+# Optional preview-site auth and config overrides
+PASSWORD_PROTECT=false
+PREVIEW_PASSWORD=
+NEXT_PUBLIC_SITE_CONFIG=
 
 # Optional (for rendering tweets more efficiently)
-#TWITTER_ACCESS_TOKEN=
+# TWITTER_ACCESS_TOKEN=
+
+# Optional Google Sheets integrations used by the form endpoints
+SPREADSHEET_ID=
+GOOGLE_CLIENT_EMAIL=
+GOOGLE_PRIVATE_KEY=
 
 # Optional (for persisting preview images to redis)
 # NOTE: if you want to enable redis, only REDIS_HOST and REDIS_PASSWORD are required
 # NOTE: don't forget to set isRedisEnabled to true in the site.config.ts file
-#REDIS_HOST=
-#REDIS_PASSWORD=
-#REDIS_USER='default'
-#REDIS_NAMESPACE='preview-images'
-NEXT_PUBLIC_NOTION_PAGE_ID=
+# REDIS_HOST=
+# REDIS_PASSWORD=
+# REDIS_USER=default
+# REDIS_NAMESPACE=preview-images

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+/output/
 
 # production
 /build
@@ -26,6 +27,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+dkim_backup.sql
+selena_1min_loom_overview.mp4
 
 # local env files
 .env

--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -520,18 +520,34 @@ export const NotionPage: React.FC<types.PageProps> = ({
     // Select all .notion-blank div elements
     const blankDivs = Array.from(document.querySelectorAll('.notion-blank'))
 
-    // Exit if there are less than 2 .notion-blank divs, as no wrapping is needed
-    if (blankDivs.length < 2) return
+    if (blankDivs.length === 0) return
+
+    const trailingCourseStopHrefs = new Set([
+      '/about',
+      '/why',
+      '/process',
+      '/privacy-policy',
+      '/terms-of-service'
+    ])
+
+    const isCourseCardBoundary = (element: Element) => {
+      if (element.classList.contains('notion-blank')) return true
+
+      const nestedLink = element.querySelector<HTMLAnchorElement>('a[href]')
+      const href = nestedLink?.getAttribute('href')
+
+      return !!(href && trailingCourseStopHrefs.has(href))
+    }
 
     // We will use a while loop to iterate over all .notion-blank elements
     let index = 0
-    while (index < blankDivs.length - 1) {
+    while (index < blankDivs.length) {
       const blankDiv = blankDivs[index]
       const elementsToWrap = []
       let nextSibling = blankDiv.nextElementSibling
 
-      // Collect all elements until reaching the next .notion-blank div
-      while (nextSibling && !nextSibling.classList.contains('notion-blank')) {
+      // Collect each course card until the next blank or the footer/about links.
+      while (nextSibling && !isCourseCardBoundary(nextSibling)) {
         elementsToWrap.push(nextSibling)
         nextSibling = nextSibling.nextElementSibling
       }

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,0 +1,87 @@
+# Railway Deployment
+
+This repo now deploys cleanly on Railway from Node `18.x`.
+
+## Current Railway Project
+
+- Project: `coursetexts-notion`
+- Service: `web`
+- Production domain: `https://web-production-2ed17.up.railway.app`
+- Preview domain: `https://web-preview-2f4d.up.railway.app`
+
+## Required Environment Variables
+
+These are required for the main site to build and boot:
+
+- `NEXT_PUBLIC_NOTION_PAGE_ID`
+- `SESSION_SECRET`
+
+These are optional, but currently used in this repo:
+
+- `NEXT_PUBLIC_NOTION_PAGE_ID_PREVIEW`
+- `NEXT_PUBLIC_GA_MEASUREMENT_ID`
+- `NEXT_PUBLIC_SITE_CONFIG`
+- `PASSWORD_PROTECT`
+- `PREVIEW_PASSWORD`
+- `SPREADSHEET_ID`
+- `GOOGLE_CLIENT_EMAIL`
+- `GOOGLE_PRIVATE_KEY`
+- `REDIS_HOST`
+- `REDIS_PASSWORD`
+- `REDIS_USER`
+- `REDIS_NAMESPACE`
+- `NEXT_PUBLIC_FATHOM_ID`
+- `NEXT_PUBLIC_POSTHOG_ID`
+- `TWITTER_ACCESS_TOKEN`
+
+## Why Railway Was Failing
+
+Two separate issues blocked deploys:
+
+1. Railway was resolving Node 16 from the repo's old engine range, but the current Notion dependency graph requires Node 18.
+2. The current Notion client returns blocks in a nested wrapper shape (`entry.value.value`) that `react-notion-x` does not handle directly.
+
+There was also a build-time Notion rate limit caused by fetching the same page set once for `getStaticPaths` and again for `getStaticProps`.
+
+## Fixes Landed In The Repo
+
+- `package.json` now pins Node to `18.x`
+- `lib/notion-api.ts` normalizes nested Notion block wrappers before the renderer sees them
+- `lib/resolve-notion-page.ts` reuses `siteMap.pageMap` during SSG to avoid duplicate Notion fetches
+- `.gitignore` excludes large local artifacts that break upload-based deploys
+
+## Preview Environment
+
+The preview site can point at a different Notion root page by setting:
+
+- `NEXT_PUBLIC_NOTION_PAGE_ID`
+- `VERCEL_ENV=preview`
+
+If preview needs different site metadata or page overrides than production, set `NEXT_PUBLIC_SITE_CONFIG` to a JSON object. Example:
+
+```json
+{
+  "domain": "preview.coursetexts.org",
+  "pageUrlOverrides": {
+    "/why": "https://www.notion.so/snaz/Coursetexts-is-open-sourcing-the-frontiers-of-knowledge-14d19a13312a80aba903d49ab333bd38",
+    "/process": "https://www.notion.so/snaz/Process-23b19a13312a8045a30bfc70e968ba51"
+  }
+}
+```
+
+This is useful when production-only routes like `/about` should not be inherited by preview.
+
+## GitHub-Driven Deploys
+
+For automatic deploys from GitHub:
+
+1. Keep the Railway service connected to `coursetexts/notion-site`
+2. Keep `main` as the production branch
+3. Store Railway env vars in the service, not in the repo
+4. Push fixes to `origin/main`
+
+## DNS Notes
+
+Railway supports apex/root domains by asking DNS providers to flatten a CNAME target. Cloudflare supports this with CNAME flattening.
+
+For `coursetexts.org`, keep the custom domain attached in Railway and point the apex at the Railway target through Cloudflare instead of Squarespace DNS.

--- a/lib/notion-api.ts
+++ b/lib/notion-api.ts
@@ -1,9 +1,46 @@
 import { NotionAPI } from '@genthegreat/notion-client'
 import pMap from 'p-map'
 
-export const notion = new NotionAPI({
+const notionClient = new NotionAPI({
   apiBaseUrl: process.env.NOTION_API_BASE_URL
 })
+
+function normalizeRecordMap(recordMap: any) {
+  if (!recordMap?.block) {
+    return recordMap
+  }
+
+  const normalizedBlocks = Object.fromEntries(
+    Object.entries(recordMap.block).map(([blockId, entry]: [string, any]) => {
+      const nestedValue = entry?.value?.value
+
+      if (!nestedValue) {
+        return [blockId, entry]
+      }
+
+      return [
+        blockId,
+        {
+          ...entry,
+          role: entry.role ?? entry.value?.role,
+          value: nestedValue
+        }
+      ]
+    })
+  )
+
+  return {
+    ...recordMap,
+    block: normalizedBlocks
+  }
+}
+
+const rawGetPage = notionClient.getPage.bind(notionClient)
+notionClient.getPage = (async (...args: Parameters<typeof rawGetPage>) => {
+  return normalizeRecordMap(await rawGetPage(...args))
+}) as typeof notionClient.getPage
+
+export const notion = notionClient
 
 // Rate-limited wrapper for getPage
 export async function getPageWithRetry(pageId: string, maxRetries = 3): Promise<any> {

--- a/lib/resolve-notion-page.ts
+++ b/lib/resolve-notion-page.ts
@@ -81,7 +81,8 @@ export async function resolveNotionPage(domain: string, rawPageId?: string) {
     pageId = site.rootNotionPageId
 
     console.log(site)
-    recordMap = await getPage(pageId)
+    const siteMap = await getSiteMap()
+    recordMap = siteMap.pageMap?.[pageId] || (await getPage(pageId))
   }
 
   const props = { site, recordMap, pageId }

--- a/lib/resolve-notion-page.ts
+++ b/lib/resolve-notion-page.ts
@@ -52,11 +52,9 @@ export async function resolveNotionPage(domain: string, rawPageId?: string) {
       pageId = siteMap?.canonicalPageMap[rawPageId]
 
       if (pageId) {
-        // TODO: we're not re-using the page recordMap from siteMaps because it is
-        // cached aggressively
-        // recordMap = siteMap.pageMap[pageId]
-
-        recordMap = await getPage(pageId)
+        // Reuse the site map's already-fetched record map during SSG to avoid
+        // a second burst of Notion API calls for every static page.
+        recordMap = siteMap.pageMap?.[pageId] || (await getPage(pageId))
 
         if (useUriToPageIdCache) {
           try {

--- a/lib/resolve-notion-page.ts
+++ b/lib/resolve-notion-page.ts
@@ -7,6 +7,36 @@ import { db } from './db'
 import { getSiteMap } from './get-site-map'
 import { getPage } from './notion'
 
+function getSiteMapRecordMap(
+  siteMap: Awaited<ReturnType<typeof getSiteMap>>,
+  pageId: string
+): ExtendedRecordMap | undefined {
+  const rawId = parsePageId(pageId, { uuid: false }) || pageId
+  const uuidId = parsePageId(pageId, { uuid: true }) || rawId
+  const candidateIds = Array.from(new Set([pageId, rawId, uuidId].filter(Boolean)))
+
+  for (const candidateId of candidateIds) {
+    const recordMap = siteMap?.pageMap?.[candidateId]
+    if (recordMap) {
+      return recordMap
+    }
+  }
+
+  for (const recordMap of Object.values(siteMap?.pageMap || {})) {
+    const blockMap = (recordMap as ExtendedRecordMap)?.block
+    if (!blockMap) continue
+
+    if (blockMap[uuidId] || blockMap[rawId]) {
+      console.warn('Resolved site map recordMap via block match', {
+        requestedPageId: pageId,
+        rawId,
+        uuidId
+      })
+      return recordMap as ExtendedRecordMap
+    }
+  }
+}
+
 export async function resolveNotionPage(domain: string, rawPageId?: string) {
   let pageId: string
   let recordMap: ExtendedRecordMap
@@ -54,7 +84,7 @@ export async function resolveNotionPage(domain: string, rawPageId?: string) {
       if (pageId) {
         // Reuse the site map's already-fetched record map during SSG to avoid
         // a second burst of Notion API calls for every static page.
-        recordMap = siteMap.pageMap?.[pageId] || (await getPage(pageId))
+        recordMap = getSiteMapRecordMap(siteMap, pageId) || (await getPage(pageId))
 
         if (useUriToPageIdCache) {
           try {
@@ -82,7 +112,7 @@ export async function resolveNotionPage(domain: string, rawPageId?: string) {
 
     console.log(site)
     const siteMap = await getSiteMap()
-    recordMap = siteMap.pageMap?.[pageId] || (await getPage(pageId))
+    recordMap = getSiteMapRecordMap(siteMap, pageId) || (await getPage(pageId))
   }
 
   const props = { site, recordMap, pageId }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "transitive-bullshit/nextjs-notion-starter-kit",
   "license": "MIT",
   "engines": {
-    "node": ">=16"
+    "node": "18.x"
   },
   "scripts": {
     "dev": "next dev",

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,8 @@ preview.coursetexts.org is the preview site with all the preview sites included,
 
 To setup, make sure to set the `NEXT_PUBLIC_NOTION_PAGE_ID` environment variable in Vercel and in .env.
 
+Railway deployment notes, required env vars, and the current production service details live in [docs/railway.md](./docs/railway.md).
+
 ---
 
 > The perfect starter kit for building websites with Next.js and Notion.
@@ -44,7 +46,7 @@ It uses Notion as a CMS, [react-notion-x](https://github.com/NotionX/react-notio
 
 **All config is defined in [site.config.ts](./site.config.ts).**
 
-This project requires a recent version of Node.js (we recommend >= 16).
+This project requires Node.js `18.x`.
 
 1. Fork / clone this repo
 2. Change a few values in [site.config.ts](./site.config.ts)


### PR DESCRIPTION
## Summary
- pin Railway builds to Node 18 and ignore large local upload artifacts
- normalize the current Notion block wrapper shape before rendering
- reuse site map page data during SSG to avoid duplicate Notion fetches and 429s
- document Railway and preview environment setup, including NEXT_PUBLIC_SITE_CONFIG

## Verification
- verified Railway production serves the home page and multiple course pages with HTTP 200
- preview environment variables were prepared separately on Railway
