### PR TITLE
[FIX] unblock Render build by relaxing Node engine constraint

### DIFF
--- a/lib/notion-api.ts
+++ b/lib/notion-api.ts
@@ -65,6 +65,15 @@ async function fillMissingBlocks(recordMap: any): Promise<any> {
     const res: any = await (notionClient as any).getBlocks(pendingIds)
     const fetched = res?.recordMap?.block || {}
 
+    // If Notion returned nothing, the remaining blocks are inaccessible.
+    // Break now instead of burning all 10 iterations on the same IDs.
+    if (!Object.keys(fetched).length) {
+      console.warn(
+        `notion fillMissingBlocks: getBlocks returned no data for ${pendingIds.length} block(s), stopping`
+      )
+      break
+    }
+
     // Normalize freshly fetched blocks into the same flat shape.
     for (const [id, entry] of Object.entries<any>(fetched)) {
       const inner = entry?.value?.value

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "transitive-bullshit/nextjs-notion-starter-kit",
   "license": "MIT",
   "engines": {
-    "node": "18.x"
+    "node": ">=18"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Relaxes `engines.node` in `package.json` from `18.x` to `>=18` so Render (running Node 21.6.2) can complete `yarn install` and build successfully
- Adds an early-exit guard in `fillMissingBlocks` so the loop stops immediately if `getBlocks` returns nothing (inaccessible blocks), instead of burning all 10 iterations on the same IDs

## Why courses were missing

The block-fetching fixes (`normalizeRecordMap` + `fillMissingBlocks`) were already on `main` since April 15–22 but were never deployed — every Render build attempt since then failed at `yarn install` before any code ran. The live site has been serving a stale pre-fix build. This PR unblocks the build so those fixes actually reach production.

## Test plan

- [ ] Render build passes with Node 21
- [ ] Homepage shows all courses (not just the first ~100 blocks worth)


TLDR;
Resolves issue where courses disappeared when Notion pages exceeded 100 blocks.
Unblock build errors by updating the package dependencies