### PR TITLE
Fix live course count

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -19,6 +19,7 @@ import * as config from '@/lib/config'
 import * as types from '@/lib/types'
 import { donate } from '@/lib/config'
 import { NOTION_PRODUCTION_URL } from '@/lib/consts'
+import { shouldHideCourseFromPublicHome } from '@/lib/course-count'
 import {
   LINK_ICON_METADATA,
   LinkIconKey,
@@ -557,8 +558,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
         .join(' ')
         .toLowerCase()
 
-      // Hide courses by Adam Cohen in production
-      if (contentText.includes('adam cohen') && isProduction) {
+      if (shouldHideCourseFromPublicHome(contentText, isProduction)) {
         elementsToWrap.forEach((element) => {
           element.remove()
         })

--- a/lib/course-count.ts
+++ b/lib/course-count.ts
@@ -1,0 +1,102 @@
+import { ExtendedRecordMap } from 'notion-types'
+import { parsePageId } from 'notion-utils'
+
+const liveCourseCountReplacements = [
+  {
+    pattern: /\bpreviously published \d+\+? courses\b/g,
+    replacement: (courseCount: number) =>
+      `previously published ${courseCount} courses`
+  },
+  {
+    pattern: /\bpublished \d+\+? open access courses\b/g,
+    replacement: (courseCount: number) =>
+      `published ${courseCount} open access courses`
+  }
+]
+
+function getBlock(recordMap: ExtendedRecordMap, blockId: string) {
+  const rawId = parsePageId(blockId, { uuid: false }) || blockId
+  const uuidId = parsePageId(blockId, { uuid: true }) || rawId
+  const candidateIds = Array.from(
+    new Set([blockId, rawId, uuidId].filter(Boolean))
+  )
+
+  for (const candidateId of candidateIds) {
+    const block = recordMap?.block?.[candidateId]?.value
+    if (block) return block
+  }
+}
+
+function getPlainTitle(block: any): string {
+  const title = block?.properties?.title
+  if (!Array.isArray(title)) return ''
+
+  return title.map((part) => (Array.isArray(part) ? part[0] : '')).join('')
+}
+
+function getCourseCardText(
+  recordMap: ExtendedRecordMap,
+  siblingIds: string[],
+  startIndex: number
+): string {
+  const parts: string[] = []
+
+  for (let index = startIndex; index < siblingIds.length; index += 1) {
+    const block = getBlock(recordMap, siblingIds[index])
+    if (!block) continue
+    if (index !== startIndex && block.type === 'page') break
+
+    const text = getPlainTitle(block).trim()
+    if (index !== startIndex && !text) break
+
+    parts.push(text)
+  }
+
+  return parts.join(' ').toLowerCase()
+}
+
+export function shouldHideCourseFromPublicHome(
+  courseText: string,
+  isProduction: boolean
+) {
+  return isProduction && courseText.toLowerCase().includes('adam cohen')
+}
+
+export function getVisibleCourseCount(
+  recordMap: ExtendedRecordMap,
+  rootPageId: string,
+  isProduction: boolean
+) {
+  const rootBlock = getBlock(recordMap, rootPageId)
+  const siblingIds = rootBlock?.content || []
+
+  return siblingIds.reduce((count: number, blockId: string, index: number) => {
+    const block = getBlock(recordMap, blockId)
+    if (block?.type !== 'page') return count
+
+    const cardText = getCourseCardText(recordMap, siblingIds, index)
+    if (shouldHideCourseFromPublicHome(cardText, isProduction)) return count
+
+    return count + 1
+  }, 0)
+}
+
+export function applyLiveCourseCount(
+  recordMap: ExtendedRecordMap,
+  courseCount: number
+) {
+  Object.values(recordMap?.block || {}).forEach((blockEntry: any) => {
+    const title = blockEntry?.value?.properties?.title
+    if (!Array.isArray(title)) return
+
+    title.forEach((part: any[]) => {
+      if (!Array.isArray(part) || typeof part[0] !== 'string') return
+
+      part[0] = liveCourseCountReplacements.reduce(
+        (text, { pattern, replacement }) =>
+          text.replace(pattern, replacement(courseCount)),
+        part[0]
+      )
+    })
+  })
+}

--- a/lib/resolve-notion-page.ts
+++ b/lib/resolve-notion-page.ts
@@ -3,6 +3,8 @@ import { parsePageId } from 'notion-utils'
 
 import * as acl from './acl'
 import { environment, pageUrlAdditions, pageUrlOverrides, site } from './config'
+import { NOTION_PRODUCTION_URL } from './consts'
+import { applyLiveCourseCount, getVisibleCourseCount } from './course-count'
 import { db } from './db'
 import { getSiteMap } from './get-site-map'
 import { getPage } from './notion'
@@ -13,7 +15,9 @@ function getSiteMapRecordMap(
 ): ExtendedRecordMap | undefined {
   const rawId = parsePageId(pageId, { uuid: false }) || pageId
   const uuidId = parsePageId(pageId, { uuid: true }) || rawId
-  const candidateIds = Array.from(new Set([pageId, rawId, uuidId].filter(Boolean)))
+  const candidateIds = Array.from(
+    new Set([pageId, rawId, uuidId].filter(Boolean))
+  )
 
   for (const candidateId of candidateIds) {
     const recordMap = siteMap?.pageMap?.[candidateId]
@@ -34,6 +38,42 @@ function getSiteMapRecordMap(
       })
       return recordMap as ExtendedRecordMap
     }
+  }
+}
+
+async function updateWhyPageCourseCount({
+  pageId,
+  rawPageId,
+  recordMap
+}: {
+  pageId: string
+  rawPageId?: string
+  recordMap: ExtendedRecordMap
+}) {
+  const whyPageId = pageUrlOverrides.why
+  const isWhyPage = rawPageId === 'why' || pageId === whyPageId
+  if (!isWhyPage) return
+
+  try {
+    const homeRecordMap =
+      pageId === site.rootNotionPageId
+        ? recordMap
+        : await getPage(site.rootNotionPageId)
+    const courseCount = getVisibleCourseCount(
+      homeRecordMap,
+      site.rootNotionPageId,
+      site.rootNotionPageId === NOTION_PRODUCTION_URL
+    )
+
+    if (courseCount > 0) {
+      applyLiveCourseCount(recordMap, courseCount)
+    }
+  } catch (err: any) {
+    console.warn('Failed to update live course count', {
+      pageId,
+      rawPageId,
+      message: err?.message
+    })
   }
 }
 
@@ -84,7 +124,8 @@ export async function resolveNotionPage(domain: string, rawPageId?: string) {
       if (pageId) {
         // Reuse the site map's already-fetched record map during SSG to avoid
         // a second burst of Notion API calls for every static page.
-        recordMap = getSiteMapRecordMap(siteMap, pageId) || (await getPage(pageId))
+        recordMap =
+          getSiteMapRecordMap(siteMap, pageId) || (await getPage(pageId))
 
         if (useUriToPageIdCache) {
           try {
@@ -114,6 +155,8 @@ export async function resolveNotionPage(domain: string, rawPageId?: string) {
     const siteMap = await getSiteMap()
     recordMap = getSiteMapRecordMap(siteMap, pageId) || (await getPage(pageId))
   }
+
+  await updateWhyPageCourseCount({ pageId, rawPageId, recordMap })
 
   const props = { site, recordMap, pageId }
   return { ...props, ...(await acl.pageAcl(props)) }


### PR DESCRIPTION
#### Description

- Count visible homepage course cards from the root Notion page instead of relying on hard-coded counts on /why
- Apply that live count to both course-count references on the why page
- Share the homepage hidden-course rule with the counter so production-only hidden courses are excluded

Fixes #33

#### Notion Test Page ID

prod /why